### PR TITLE
Minor tweaks to run on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+test.sh
+test.bat

--- a/Protobuild.toml
+++ b/Protobuild.toml
@@ -17,7 +17,7 @@ plugins = ["grpc"]
   # treat the root of the project as an include, but this may not be necessary.
   #
   # "." is included by default
-  before = ["."]
+  # before = ["."]
 
   # Paths that should be treated as include roots in relation to the vendor
   # directory. These will be calculated with the vendor directory nearest the

--- a/main.go
+++ b/main.go
@@ -172,11 +172,11 @@ func gopathSrc() (string, error) {
 	}
 
 	var elements []string
-	for _, element := range strings.Split(gopathAll, ":") { // TODO(stevvooe): Make this work on windows.
+	for _, element := range strings.Split(gopathAll, string(filepath.ListSeparator)) {
 		elements = append(elements, filepath.Join(element, "src"))
 	}
 
-	return strings.Join(elements, ":"), nil
+	return strings.Join(elements, string(filepath.ListSeparator)), nil
 }
 
 // gopathCurrent provides the top-level gopath for the current generation.
@@ -187,7 +187,7 @@ func gopathCurrent() (string, error) {
 		return "", fmt.Errorf("must be run from a gopath")
 	}
 
-	return strings.Split(gopathAll, ":")[0], nil
+	return strings.Split(gopathAll, string(filepath.ListSeparator))[0], nil
 }
 
 var errVendorNotFound = fmt.Errorf("no vendor dir found")
@@ -195,7 +195,7 @@ var errVendorNotFound = fmt.Errorf("no vendor dir found")
 // closestVendorDir walks up from dir until it finds the vendor directory.
 func closestVendorDir(dir string) (string, error) {
 	dir = filepath.Clean(dir)
-	for dir != "" && dir != string(filepath.Separator) { // TODO(stevvooe): May not work on windows
+	for dir != filepath.VolumeName(dir)+string(filepath.Separator) {
 		vendor := filepath.Join(dir, "vendor")
 		fi, err := os.Stat(vendor)
 		if err != nil {

--- a/protoc.go
+++ b/protoc.go
@@ -5,13 +5,14 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"text/template"
 )
 
 var (
 	tmpl = template.Must(template.New("protoc").Parse(`protoc -I
 	{{- range $index, $include := .Includes -}}
-		{{if $index}}:{{end -}}
+		{{if $index}}` + string(filepath.ListSeparator) + `{{end -}}
 			{{.}}
 		{{- end }} --
 	{{- .Name -}}_out={{if .Plugins}}plugins={{- range $index, $plugin := .Plugins -}}
@@ -54,8 +55,8 @@ func (p *protocCmd) run() error {
 	}
 
 	// pass to sh -c so we don't need to re-split here.
-	args := []string{"-c", arg}
-	cmd := exec.Command("sh", args...)
+	args := []string{shArg, arg}
+	cmd := exec.Command(shCmd, args...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	return cmd.Run()

--- a/protoc_unix.go
+++ b/protoc_unix.go
@@ -1,0 +1,8 @@
+// +build !windows
+
+package main
+
+const (
+	shCmd = "sh"
+	shArg = "-c"
+)

--- a/protoc_windows.go
+++ b/protoc_windows.go
@@ -1,0 +1,6 @@
+package main
+
+const (
+	shCmd = "cmd.exe"
+	shArg = "/c"
+)


### PR DESCRIPTION
* use stdlib path list separator instead of ":" literal
* execute sh _or_ cmd depending on GOOS

Signed-off-by: Bruce A Downs <bruceadowns@gmail.com>