### PR TITLE
Fix #8 errors when generate descriptors

### DIFF
--- a/descriptors.go
+++ b/descriptors.go
@@ -65,6 +65,7 @@ func (d *descriptorSet) marshalTo(w io.Writer) error {
 		"google.protobuf.FileDescriptorSet",
 
 		// TODO(stevvooe): Come up with better way to resolve this path.
+		"-I/usr/local/include",
 		"/usr/local/include/google/protobuf/descriptor.proto",
 	}
 


### PR DESCRIPTION
Fix #8 
Add '-I/usr/local/include' arg in command for generating merged descriptors.

Signed-off-by: He Xiaoxi <tossmilestone@gmail.com>