### PR TITLE
protobuild: package relative includes

### DIFF
--- a/Protobuild.toml
+++ b/Protobuild.toml
@@ -23,11 +23,25 @@ plugins = ["grpc"]
   # directory. These will be calculated with the vendor directory nearest the
   # target package.
   #
+  # This should be used only in cases where imports must be resolved from the
+  # vendor package and not a GOPATH package. Most users should employ the
+  # `packages` configuration and let protobuild resolve the existing package.
+  #
   # With the example below, we import the gogo protobufs from the vendor
   # directory.
   #
   # This is empty by default.
   # vendored = ["github.com/gogo/protobuf"]
+
+  # Packages will add imports that are relative to the vendor path or GOPATH.
+  # For example, if we import `gogoproto/gogo.proto`, we would add an import
+  # root of `$GOPATH/github.com/gogo/protobuf`, in addition to the vendored
+  # directory.
+  #
+  # If in doubt, use this over `vendored` configuration for your project.
+  #
+  # This is empty by default.
+  # packages = ["github.com/gogo/protobuf"]
 
   # Paths that will be added untouched to the end of the includes. We use
   # `/usr/local/include` to pickup the common install location of protobuf.

--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ type config struct {
 	Includes  struct {
 		Before   []string
 		Vendored []string
+		Packages []string
 		After    []string
 	}
 
@@ -35,6 +36,7 @@ func newDefaultConfig() config {
 		Includes: struct {
 			Before   []string
 			Vendored []string
+			Packages []string
 			After    []string
 		}{
 			Before: []string{"."},

--- a/descriptors.go
+++ b/descriptors.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
@@ -74,6 +75,7 @@ func (d *descriptorSet) marshalTo(w io.Writer) error {
 	cmd.Stdout = w
 	cmd.Stderr = os.Stderr
 
+	os.Stdout.WriteString(strings.Join(args, " "))
 	return cmd.Run()
 }
 


### PR DESCRIPTION
Up to this point, most projects have relied on vendoring for include
path resolution relative to package import paths. This adds the ability
to just specify that you want a particular Go package to be used as an
include root and protobuild will resolve it.

Signed-off-by: Stephen J Day <stephen.day@docker.com>