### PR TITLE
Don't hardcode path to google/protobuf/descriptor.proto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 go:
-    - 1.7.x
-    - 1.8.x
+    - 1.10.x
+    - 1.11.x
     - master

--- a/Protobuild.toml
+++ b/Protobuild.toml
@@ -44,9 +44,9 @@ plugins = ["grpc"]
   # packages = ["github.com/gogo/protobuf"]
 
   # Paths that will be added untouched to the end of the includes. We use
-  # `/usr/local/include` to pickup the common install location of protobuf.
+  # a few paths to pickup the common install locations for protobuf.
   # This is the default.
-  # after = ["usr/local/include"]
+  # after = ["usr/local/include", "/usr/include"]
 
 # This section let's us map protobuf imports to Go packages. These will become
 # `-M` directives in the call to the go protobuf generator.

--- a/config.go
+++ b/config.go
@@ -51,7 +51,7 @@ func newDefaultConfig() config {
 			After    []string
 		}{
 			Before: []string{"."},
-			After:  []string{"/usr/local/include"},
+			After:  []string{"/usr/local/include", "/usr/include"},
 		},
 	}
 }

--- a/descriptors.go
+++ b/descriptors.go
@@ -76,7 +76,9 @@ func (d *descriptorSet) marshalTo(w io.Writer) error {
 	cmd.Stdout = w
 	cmd.Stderr = os.Stderr
 
-	fmt.Println(strings.Join(args, " "))
+	if !quiet {
+		fmt.Println(strings.Join(args, " "))
+	}
 	return cmd.Run()
 }
 


### PR DESCRIPTION
Despite the ability to specify multiple include directories
in `config.Include.After`, the `/usr/local/bin` path to
`google/protobuf/descriptor.proto` is hardcoded in
`func (*descriptorSet).marshalTo()`.

Fix by passing `c.Config.After` (i.e. list of user-supplied
include paths) to the above function, and iterate over those
to search for `descriptor.proto`.

This (together with the addition of `/usr/include` path to
`config.Include.After`) makes it possible to use protobuilder
with distro-installed protoc (e.g. with Debian/Ubuntu it is
`apt install libprotobuf-dev protobuf-compiler`).